### PR TITLE
EventInfo.tpl: Add condition for document.ready logic.

### DIFF
--- a/templates/CRM/Calendar/Page/Field/EventInfo.tpl
+++ b/templates/CRM/Calendar/Page/Field/EventInfo.tpl
@@ -6,10 +6,12 @@
 <script type="text/javascript">
   (function() {
     CRM.$(document).ready(function () {
-      var registerParticipantElement = CRM.$('[data-li="register_participant"]');
+      if (CRM.$("div.crm-actions-ribbon").length) {
+        var registerParticipantElement = CRM.$('[data-li="register_participant"]');
 
-      CRM.$(registerParticipantElement).prependTo('#crm-participant-list > .crm-participant-list-inner > ul');
-      registerParticipantElement.show();
+        CRM.$(registerParticipantElement).prependTo('#crm-participant-list > .crm-participant-list-inner > ul');
+        registerParticipantElement.show();
+      }
     });
   })();
 </script>


### PR DESCRIPTION
At present, the unconditional nature of registerParticipantElement.show() causes a stray link to be inserted in public event pages.

Making it dependent on the existence of .crm-actions-ribbon prevents this from happening.